### PR TITLE
auto updater service

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The font browser built for designers.",
   "private": true,
   "main": "packages/main/dist/index.cjs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "email": "lucas.stettner@gmail.com",
     "name": "Lucas Stettner"
@@ -30,6 +30,7 @@
     "@vanilla-extract/sprinkles": "^1.5.0",
     "@vanilla-extract/vite-plugin": "^3.6.1",
     "clsx": "^1.2.1",
+    "electron-log": "^4.4.8",
     "electron-updater": "^5.3.0",
     "font-scanner": "^0.2.1",
     "framer-motion": "^7.6.7",

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, ipcMain } from 'electron';
 import { join } from 'path';
 import { URL } from 'url';
 import { getAvailableFontsSync } from 'font-scanner';
-import { autoUpdater } from 'electron-updater';
+import { AutoUpdater } from './services';
 
 async function createWindow() {
   const browserWindow = new BrowserWindow({
@@ -21,6 +21,8 @@ async function createWindow() {
     },
   });
 
+  new AutoUpdater(browserWindow);
+
   ipcMain.handle('getFonts', () => {
     return getAvailableFontsSync();
   });
@@ -34,7 +36,6 @@ async function createWindow() {
    * @see https://github.com/electron/electron/issues/25012 for the afford mentioned issue.
    */
   browserWindow.on('ready-to-show', () => {
-    autoUpdater.checkForUpdatesAndNotify();
     browserWindow?.show();
   });
 

--- a/packages/main/src/services/AutoUpdater.ts
+++ b/packages/main/src/services/AutoUpdater.ts
@@ -1,0 +1,47 @@
+import { BrowserWindow } from 'electron';
+import { autoUpdater } from 'electron-updater';
+
+export class AutoUpdater {
+  log: any;
+  window: BrowserWindow;
+
+  constructor(window: BrowserWindow) {
+    this.window = window;
+    this.log = require('electron-log');
+
+    this.log.transports.file.level = 'debug';
+    autoUpdater.logger = this.log;
+
+    this._setupLogs();
+    this._listenForUpdates();
+  }
+  private _listenForUpdates() {
+    this.window.on('ready-to-show', () => {
+      autoUpdater.checkForUpdatesAndNotify();
+    });
+  }
+
+  private _setupLogs() {
+    autoUpdater.on('checking-for-update', () => {
+      this.log.info('Checking for update...');
+    });
+    autoUpdater.on('update-available', () => {
+      this.log.info('Update available.');
+    });
+    autoUpdater.on('update-not-available', () => {
+      this.log.info('Update not available.');
+    });
+    autoUpdater.on('error', err => {
+      this.log.info('Error in auto-updater. ' + err);
+    });
+    autoUpdater.on('download-progress', progressObj => {
+      let log_message = 'Download speed: ' + progressObj.bytesPerSecond;
+      log_message = log_message + ' - Downloaded ' + progressObj.percent + '%';
+      log_message = log_message + ' (' + progressObj.transferred + '/' + progressObj.total + ')';
+      this.log.info(log_message);
+    });
+    autoUpdater.on('update-downloaded', () => {
+      this.log.info('Update downloaded');
+    });
+  }
+}

--- a/packages/main/src/services/index.ts
+++ b/packages/main/src/services/index.ts
@@ -1,0 +1,1 @@
+export { AutoUpdater } from './AutoUpdater';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,6 +1837,11 @@ electron-builder@23.6.0:
     simple-update-notifier "^1.0.7"
     yargs "^17.5.1"
 
+electron-log@^4.4.8:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.4.8.tgz#fcb9f714dbcaefb6ac7984c4683912c74730248a"
+  integrity sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA==
+
 electron-notarize@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.2.2.tgz#ebf2b258e8e08c1c9f8ff61dc53d5b16b439daf4"


### PR DESCRIPTION
- fix compile
- add title animation
- add basic font card
- virtualized list component
- add virtualized scrolling
- fix card scroll align
- overscan more items
- polish
- cleaup animation
- see more styles
- overly polish title changes
- fix asset folder
- scrolling interaction
- fix build step
- small fixes
- change window name
- change font provider
- fix top bar scroller
- clean up content
- fix lint
- only target mac-os
- add property and onetoone metadata reflection & db mirroring
- change on-to-one to many-to-one
- progress on incremental hydration
- cleaup
- switch to swc
- fix lint
- change apis
- update latest designs
- remove overengineered latent model injection
- remove idb
- fresh start
- set up sprinkles better
- implement list and preview components
- style tweaks
- setup new component
- back to esbuild
- add text component
- add basic weight preivew
- add basic size slider
- cleanup
- style tweaks
- new weight designs
- interaction changes and tweaks
- change preview
- builder changes
- fix window controls
- bump version
- add auto-updater & fix traffic lights
- bump version
- test auto-updating
- fix electron builder public config
- remove gatekeeper
- test auto update
- add auto updater logging
- bump version
- add better logging and service
