### PR TITLE
fix font imports

### DIFF
--- a/packages/renderer/src/components/WindowControls/styles.css.ts
+++ b/packages/renderer/src/components/WindowControls/styles.css.ts
@@ -14,8 +14,8 @@ export const container = style({
 });
 
 export const trafficLight = style({
-  width: '12px',
-  height: '12px',
+  width: '10px',
+  height: '10px',
   backgroundColor: vars.colors.textSecondary,
   borderRadius: vars.borderRadii.circle,
 });

--- a/packages/renderer/src/styles/app.css.ts
+++ b/packages/renderer/src/styles/app.css.ts
@@ -23,21 +23,21 @@ Object.values(fontWeights).forEach(weight => {
   globalFontFace('Hubot-Sans', {
     fontStyle: 'normal',
     fontWeight: weight,
-    src: `url("fonts/Hubot-Sans/Hubot-Sans.woff") format("woff"),
-        url("fonts/Hubot-Sans/Hubot-Sans.woff2") format("woff2")`,
+    src: `url("/fonts/Hubot-Sans/Hubot-Sans.woff") format("woff"),
+          url("/fonts/Hubot-Sans/Hubot-Sans.woff2") format("woff2")`,
   });
 });
 
 globalFontFace('IBM Plex Mono', {
   fontStyle: 'normal',
   fontWeight: fontWeights.medium,
-  src: `url("fonts/IBMPlexMono/IBMPlexMono-Medium.woff") format("woff"),
-        url("fonts/IBMPlexMono/IBMPlexMono-Medium.woff2") format("woff2")`,
+  src: `url("/fonts/IBMPlexMono/IBMPlexMono-Medium.woff") format("woff"),
+        url("/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2") format("woff2")`,
 });
 
 globalFontFace('VC Henrietta', {
   fontStyle: 'normal',
   fontWeight: fontWeights.bold,
-  src: `url("fonts/VCHenrietta/VCHenrietta-Bold.woff") format("woff"),
-        url("fonts/VCHenrietta/VCHenrietta-Bold.woff2") format("woff2")`,
+  src: `url("/fonts/VCHenrietta/VCHenrietta-Bold.woff") format("woff"),
+        url("/fonts/VCHenrietta/VCHenrietta-Bold.woff2") format("woff2")`,
 });

--- a/packages/renderer/src/styles/tokens.ts
+++ b/packages/renderer/src/styles/tokens.ts
@@ -103,9 +103,9 @@ export const letterSpacing = {
 };
 
 export const fonts = {
-  heading: 'VC Henrietta, "Helvetica Neue", HelveticaNeue, Helvetica, sans-serif',
-  body: 'Hubot-Sans, -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif',
-  mono: 'IBM Plex Mono, "Roboto Mono", Menlo, monospace',
+  heading: '"VC Henrietta", "Helvetica Neue", HelveticaNeue, Helvetica, sans-serif',
+  body: '"Hubot-Sans", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif',
+  mono: '"IBM Plex Mono", "Roboto Mono", Menlo, monospace',
 };
 
 export const lineHeights = {


### PR DESCRIPTION
- fix compile
- add title animation
- add basic font card
- virtualized list component
- add virtualized scrolling
- fix card scroll align
- overscan more items
- polish
- cleaup animation
- see more styles
- overly polish title changes
- fix asset folder
- scrolling interaction
- fix build step
- small fixes
- change window name
- change font provider
- fix top bar scroller
- clean up content
- fix lint
- only target mac-os
- add property and onetoone metadata reflection & db mirroring
- change on-to-one to many-to-one
- progress on incremental hydration
- cleaup
- switch to swc
- fix lint
- change apis
- update latest designs
- remove overengineered latent model injection
- remove idb
- fresh start
- set up sprinkles better
- implement list and preview components
- style tweaks
- setup new component
- back to esbuild
- add text component
- add basic weight preivew
- add basic size slider
- cleanup
- style tweaks
- new weight designs
- interaction changes and tweaks
- change preview
- builder changes
- fix window controls
- bump version
- add auto-updater & fix traffic lights
- bump version
- test auto-updating
- fix electron builder public config
- remove gatekeeper
- test auto update
- add auto updater logging
- bump version
- add better logging and service
- autoupdater test
- dynamic import autoupdater & change mac target
- version bump
- another autoupdater test
- notarize properly
- remove plist
- update icon
- final test
- fix code signing
- bump
- remove menu options
- fix noterize script
- remove autoupdater logs
- add mit licence
- add fonts with licences
- add backup fonts
- bump back version to 1.0.0
- Update README.md
- fix fonts and window controls
